### PR TITLE
docker: add py3 support and upgrade dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,37 @@
 # Environment: Jupyter 1.0.0 with IPython 5.0.0 kernel on CentOS7
 FROM centos:7
 
+# Set system locale
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
 # hadolint ignore=DL3033
 RUN yum install -y epel-release && yum clean all
 
 # hadolint ignore=DL3033
 RUN yum install -y \
       gcc \
-      python-devel \
-      python-pip \
+      python3-devel \
+      python3-pip \
       && yum clean all
 
 # hadolint ignore=DL3013
-RUN pip install --upgrade pip
-RUN pip install \
-      ipython==5.0.0 \
+RUN pip3 install --upgrade pip
+RUN pip3 install \
+      ipython==7.16.1 \
       jupyter==1.0.0 \
-      jupyter-client==5.2.3 \
-      jupyter-console==5.2.0 \
-      jupyter-core==4.4.0 \
-      matplotlib==2.1.2 \
-      nbconvert==5.3.1 \
-      pandas==0.22.0 \
-      papermill==0.13.4 \
-      ipykernel==4.8.2
+      jupyter-client==6.1.12 \
+      jupyter-console==6.4.0 \
+      jupyter-core==4.7.1 \
+      matplotlib==3.3.4 \
+      nbconvert==6.0.7 \
+      pandas==1.1.5 \
+      papermill==2.3.3 \
+      # FIXME: Pin black to be able to create the cache folders manually and avoid errors.
+      # Related issue: https://github.com/nteract/papermill/issues/498
+      black==21.7b0 \
+      ipykernel==5.5.5
+
+# FIXME: Create `black` cache folder manually
+# hadolint ignore=SC2174
+RUN mkdir -m 770 -p /.cache/black/21.7b0/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: Dockerfile
 	docker build -t $(IMAGE) .
 
 test:
-	docker run -i --rm $(IMAGE) jupyter --version | grep -q ^4.4.0
+	docker run -i --rm $(IMAGE) jupyter --version | grep -q "jupyter core     : 4.7.1"
 
 lint:
 	docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile


### PR DESCRIPTION
closes #6

- [x] Push image to Docker Hub with tag 2.0.0 - https://hub.docker.com/r/reanahub/reana-env-jupyter/tags