### PR TITLE
docker: add --no-cache-dir to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN yum install -y \
 
 # hadolint ignore=DL3013
 RUN pip3 install --upgrade pip
-RUN pip3 install \
+RUN pip3 install --no-cache-dir \
       ipython==7.16.1 \
       jupyter==1.0.0 \
       jupyter-client==6.1.12 \


### PR DESCRIPTION
This PR disables the pip cache when installing requirements. This is a common practice when installing packages on Docker images, as it helps reduce images size. In the case of `reana-env-jupyter`, the resulting image shrink from `745` MBs to `678` MBs, ~67 MBs in total.

This optimization comes from discussion on https://github.com/reanahub/reana-server/pull/396