### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,18 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+
+format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2023, 2024, 2026 CERN.
+# Copyright (C) 2020, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,8 +9,19 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+  build-docker:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-format-shfmt:
+      - name: Build image
+        run: make build
+
+      - name: Test image
+        run: make test
+
+  format-shfmt:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -47,6 +58,29 @@ format-shfmt:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-hadolint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Dockerfile compliance
+        run: make lint
+
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -58,34 +92,11 @@ format-shfmt:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
-  lint-hadolint:
+  lint-yamllint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Check Dockerfile compliance
-        run: make lint
-
-  build-docker:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build image
-        run: make build
-
-      - name: Test image
-        run: make test
-
-lint-yamllint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,21 @@ jobs:
 
       - name: Test image
         run: make test
+
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2024 CERN.
+# Copyright (C) 2020, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on: [push, pull_request]
 
@@ -28,12 +28,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -44,9 +44,9 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck
 
-  lint-dockerfile:
+  lint-hadolint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,20 @@ jobs:
       - name: Test image
         run: make test
 
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
-# Allow long lines (to be fixed when prettier is added)
-MD013: false
+# Allow long lines in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
 # Allow flexible list spacing

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Allow long lines (to be fixed when prettier is added)
+MD013: false
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow flexible list spacing
+MD032: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -6,43 +6,45 @@
 
 ## About
 
-`reana-env-jupyter` provides a container image with encapsulated runtime execution
-environment for [Jupyter](https://jupyter.org/) notebook based data analyses. It is
-basically an example how a user could encapsulate a notebook environment using Jupyter
-notebooks with IPython kernel running on Ubuntu 24.04 platform. The container also
-provides several convenient Python packages such as [Pandas](https://pandas.pydata.org/)
-data analysis library or [Papermill](https://github.com/nteract/papermill) notebook
-parametrisation and execution utility.
+`reana-env-jupyter` provides a container image with encapsulated runtime
+execution environment for [Jupyter](https://jupyter.org/) notebook based data
+analyses. It is basically an example how a user could encapsulate a notebook
+environment using Jupyter notebooks with IPython kernel running on Ubuntu 24.04
+platform. The container also provides several convenient Python packages such as
+[Pandas](https://pandas.pydata.org/) data analysis library or
+[Papermill](https://github.com/nteract/papermill) notebook parametrisation and
+execution utility.
 
-`reana-env-jupyter` was developed for use in the [REANA](http://www.reana.io/) reusable
-and reproducible research data analysis platform.
+`reana-env-jupyter` was developed for use in the [REANA](http://www.reana.io/)
+reusable and reproducible research data analysis platform.
 
 ## Usage
 
-You can use `reana-env-jupyter` provided "as is" and simply mount your own Python code
-and notebooks to the running container.
+You can use `reana-env-jupyter` provided "as is" and simply mount your own
+Python code and notebooks to the running container.
 
-Alternatively, you can also use `reana-env-jupyter` as a base image for notebook-based
-analyses. Just start your `Dockerfile` from this base image and add your own custom code
-on top:
+Alternatively, you can also use `reana-env-jupyter` as a base image for
+notebook-based analyses. Just start your `Dockerfile` from this base image and
+add your own custom code on top:
 
-```
+```dockerfile
 FROM docker.io/reanahub/reana-env-jupyter
 ADD my-notebook.ipynb /code/
 [...]
 ```
 
-Here are several complete examples on how to use `reana-env-jupyter` environment in your
-analyses:
+Here are several complete examples on how to use `reana-env-jupyter` environment
+in your analyses:
 
-- [reana-demo-worldpopulation](https://github.com/reanahub/reana-demo-worldpopulation)
+-
+[reana-demo-worldpopulation](https://github.com/reanahub/reana-demo-worldpopulation)
 
 ## Development
 
 If you would like to contribute to `reana-env-jupyter` development, you can take
 advantage of the provided `Makefile`:
 
-```
+```console
 $ make build  # build a new version of the container image
 $ make test   # test the built image
 $ make push   # push it to Docker Hub

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ ADD my-notebook.ipynb /code/
 Here are several complete examples on how to use `reana-env-jupyter` environment
 in your analyses:
 
--
-[reana-demo-worldpopulation](https://github.com/reanahub/reana-demo-worldpopulation)
+- [reana-demo-worldpopulation](https://github.com/reanahub/reana-demo-worldpopulation)
 
 ## Development
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_shfmt() {
+    find . -name "*.sh" -exec shfmt -d {} \+
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -31,7 +35,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -52,6 +56,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_shfmt
     lint_commitlint
     lint_shellcheck
     lint_yamllint
@@ -61,6 +66,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all              Perform all checks [default]"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
@@ -76,6 +82,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -47,6 +47,10 @@ lint_commitlint() {
     fi
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
@@ -58,6 +62,7 @@ lint_yamllint() {
 all() {
     format_shfmt
     lint_commitlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -65,12 +70,13 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -84,6 +90,7 @@ case $arg in
 --help) help ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -47,9 +47,14 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     lint_commitlint
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -59,6 +64,7 @@ help() {
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -72,5 +78,6 @@ case $arg in
 --help) help ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     find . -name "*.sh" -exec shfmt -d {} \+
 }
@@ -60,6 +64,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_markdownlint
@@ -71,6 +76,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all                Perform all checks [default]"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -88,6 +94,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-markdownlint) lint_markdownlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024, 2025 CERN.
+# Copyright (C) 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,7 +9,7 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
@@ -43,23 +43,34 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
+all() {
+    lint_commitlint
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.