### PR TITLE
ci(commitlint): prefer locally installed commitlint over npx

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,7 @@ format_prettier() {
 }
 
 format_shfmt() {
-    find . -name "*.sh" -exec shfmt -d {} \+
+    shfmt -d .
 }
 
 lint_commitlint() {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,7 +21,11 @@ lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)


### PR DESCRIPTION
Prefer using a locally installed commitlint over npx, so that
developers who have commitlint installed via brew or npm global
can benefit from faster execution without npx overhead.
